### PR TITLE
Added module dependencies instead of nesting multiple `DiScopeBuilder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,66 @@ Widget build(BuildContext context) {
 
 This ensures the user sees a loading state while the necessary dependencies are being initialized.
 
+### Module Dependencies
+
+Instead of nesting multiple `DiScopeBuilder` widgets, a module can declare its own dependencies via the `dependencies`
+constructor parameter. Dependency modules are initialized before the main module's `setup()` runs, and their
+registrations are available through the same scope.
+
+```dart
+// Before: nested DiScopeBuilder widgets
+DiScopeBuilder(
+  createModule: MediaDiModule.new,
+  builder: (_, __) => DiScopeBuilder(
+    createModule: BannerDiModule.new,
+    builder: (_, __) => DiScopeBuilder(
+      createModule: ToursDiModule.new,
+      builder: (context, scope) => ToursScreen(
+        toursBloc: scope.get<ToursBloc>(),
+        bannerBloc: scope.get<BannerBloc>(),
+      ),
+    ),
+  ),
+)
+
+// After: single DiScopeBuilder, deps declared in the module
+class ToursDiModule extends DiModule {
+  ToursDiModule() : super(dependencies: [MediaDiModule(), BannerDiModule()]);
+
+  @override
+  void setup(SyncRegistrar it) {
+    it.registerFactory(() => ToursBloc(repo: get<ToursRepo>()));
+  }
+}
+
+DiScopeBuilder(
+  createModule: ToursDiModule.new,
+  builder: (context, scope) => ToursScreen(
+    toursBloc: scope.get<ToursBloc>(),
+    bannerBloc: scope.get<BannerBloc>(), // inherited from BannerDiModule
+  ),
+)
+```
+
+All dependency registrations are merged into the same `_parentEntities` map via `mergeFrom` — later deps overwrite
+earlier ones for the same type. The main module's own `setup()` writes to `_entities`, which is always checked first
+by `get()`.
+
+```dart
+class MyModule extends DiModule {
+  // ModuleB is merged after ModuleA — its String registration wins over ModuleA's
+  MyModule() : super(dependencies: [ModuleA(), ModuleB()]);
+
+  @override
+  void setup(SyncRegistrar it) {
+    // registered in _entities — always wins over anything in _parentEntities
+    it.registerFactory<String>(() => 'own');
+  }
+}
+```
+
+Dependencies are disposed automatically when the main module is disposed.
+
 ## Advanced Topics
 
 ### Scoped Hierarchies

--- a/lib/src/di_container/di_container.dart
+++ b/lib/src/di_container/di_container.dart
@@ -112,6 +112,11 @@ class DiContainer implements SyncRegistrar, AsyncRegistrar {
     }
   }
 
+  void mergeFrom(DiContainer other) {
+    _parentEntities.addAll(other._parentEntities);
+    _parentEntities.addAll(other._entities);
+  }
+
   void _checkScope<T>() {
     if (_entities.containsKey(T)) {
       throw Exception("$T is already registered in current scope");

--- a/lib/src/di_module/base_di_module.dart
+++ b/lib/src/di_module/base_di_module.dart
@@ -24,6 +24,9 @@ part 'di_module_async.dart';
 /// This class is sealed and extends [ChangeNotifier], which means it can notify
 /// listeners about changes in the state.
 sealed class BaseDiModule extends ChangeNotifier implements Scope {
+  BaseDiModule({this.dependencies = const []});
+  final List<BaseDiModule> dependencies;
+
   DiContainer _diContainer = DiContainer();
 
   bool _isInitialized = false;
@@ -47,25 +50,44 @@ sealed class BaseDiModule extends ChangeNotifier implements Scope {
   ///
   /// - [onInit]: Callback to be executed when initialization completes.
   /// - [isNeedNotify]: If `true`, notifies listeners after initialization.
-  void _init(Function() onInit, {bool isNeedNotify = true}) {
-    final module = this;
-
+  void _runSetup(Function() onInit, BaseDiModule module) {
     switch (module) {
       case DiModule():
         module.setup(_diContainer);
         onInit();
-        break;
       case DiModuleAsync():
         module.setup(_diContainer).then(
-              (_) => _diContainer.allReady().then(
-                    (_) => onInit(),
-                  ),
+              (_) => _diContainer.allReady().then((_) => onInit()),
             );
-        break;
+    }
+  }
+
+  void _init(Function() onInit, {bool isNeedNotify = true}) {
+    final module = this;
+
+    void complete() {
+      _isInitialized = true;
+      if (isNeedNotify) _notify();
+      onInit();
     }
 
-    _isInitialized = true;
-    if (isNeedNotify) _notify();
+    if (dependencies.isEmpty) {
+      _runSetup(complete, module);
+    } else {
+      final depFutures = dependencies.map((dep) {
+        final completer = Completer<void>();
+        dep._diContainer = DiContainer.fromScope(_diContainer);
+        dep._init(completer.complete, isNeedNotify: false);
+        return completer.future;
+      }).toList();
+
+      Future.wait(depFutures).then((_) {
+        for (final dep in dependencies) {
+          _diContainer.mergeFrom(dep._diContainer);
+        }
+        _runSetup(complete, module);
+      });
+    }
   }
 
   /// Notifies all listeners about changes in the module state.
@@ -91,6 +113,9 @@ sealed class BaseDiModule extends ChangeNotifier implements Scope {
   /// - [parent]: The parent DI module whose scope will be used for updating.
   void _updateScope(BaseDiModule? parent) {
     _diContainer.updateScope(parent?._diContainer);
+    for (final dep in dependencies) {
+      _diContainer.mergeFrom(dep._diContainer);
+    }
   }
 
   /// Pops the current scope
@@ -99,6 +124,7 @@ sealed class BaseDiModule extends ChangeNotifier implements Scope {
   /// Returns a [Future] that completes once the scope has been reset.
   Future<void> _popScope() async {
     await _reset(isNeedNotify: false);
+    await Future.wait(dependencies.map((dep) => dep._popScope()));
   }
 
   /// Resets the current module's scope

--- a/lib/src/di_module/di_module.dart
+++ b/lib/src/di_module/di_module.dart
@@ -8,6 +8,8 @@ part of 'base_di_module.dart';
 /// dependency registrations using a [SyncRegistrar],
 /// which handles the registration of non-async factories and instances.
 abstract class DiModule extends BaseDiModule implements Scope {
+  DiModule({super.dependencies = const []});
+
   /// Sets up the module by registering dependencies
   /// into the provided [SyncRegistrar].
   ///

--- a/lib/src/di_module/di_module_async.dart
+++ b/lib/src/di_module/di_module_async.dart
@@ -9,6 +9,8 @@ part of 'base_di_module.dart';
 /// using an [AsyncRegistrar], which handles the registration of async
 /// factories and instances.
 abstract class DiModuleAsync extends BaseDiModule implements Scope {
+  DiModuleAsync({super.dependencies = const []});
+
   /// Asynchronously sets up the module by registering dependencies
   /// into the provided [AsyncRegistrar].
   ///

--- a/test/di_module_dependencies_test.dart
+++ b/test/di_module_dependencies_test.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:take_it/src/di_module/base_di_module.dart';
+import 'package:take_it/src/registrar/sync_registrar.dart';
+
+// ignore_for_file: prefer_const_constructors
+
+class _ModuleA extends DiModule {
+  @override
+  void setup(SyncRegistrar it) {
+    it.registerFactory<String>(() => 'A');
+  }
+}
+
+class _ModuleB extends DiModule {
+  @override
+  void setup(SyncRegistrar it) {
+    it.registerFactory<String>(() => 'B');
+    it.registerFactory<double>(() => 2.0);
+  }
+}
+
+class _ModuleC extends DiModule {
+  @override
+  void setup(SyncRegistrar it) {
+    it.registerFactory<int>(() => 42);
+  }
+}
+
+class _ModuleBWithDepC extends DiModule {
+  _ModuleBWithDepC() : super(dependencies: [_ModuleC()]);
+
+  @override
+  void setup(SyncRegistrar it) {
+    it.registerFactory<double>(() => 2.0);
+  }
+}
+
+bool _disposed = false;
+
+class _DisposableModule extends DiModule {
+  @override
+  void setup(SyncRegistrar it) {
+    it.registerSingleton<String>(
+      'dep_value',
+      dispose: (_) {
+        _disposed = true;
+      },
+    );
+  }
+}
+
+class _MainWithDisposableDep extends DiModule {
+  _MainWithDisposableDep() : super(dependencies: [_DisposableModule()]);
+
+  @override
+  void setup(SyncRegistrar it) {
+    it.registerFactory<int>(() => 1);
+  }
+}
+
+void main() {
+  testWidgets(
+    '1. dep registrations are visible from main module',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiScopeBuilder(
+            createModule: () => DiModule$WithDep([_ModuleA()]),
+            builder: (context, scope) {
+              return Text(scope.get<String>());
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('A'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '2. last dep overrides first dep for same type',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiScopeBuilder(
+            createModule: () => _MainNoOwnString([_ModuleA(), _ModuleB()]),
+            builder: (context, scope) {
+              return Text(scope.get<String>());
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      // B is last → wins
+      expect(find.text('B'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '3. main module own registration overrides dep registration',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiScopeBuilder(
+            createModule: () => _MainOverridesString([_ModuleA()]),
+            builder: (context, scope) {
+              return Text(scope.get<String>());
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('own'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '4. dep registration overrides widget-tree parent registration',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiScopeBuilder(
+            createModule: _ModuleA.new, // registers String='A' as parent
+            builder: (context, _) {
+              return DiScopeBuilder(
+                createModule: () => _MainNoOwnString([_ModuleB()]),
+                builder: (context, scope) {
+                  return Text(scope.get<String>());
+                },
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      // dep B ('B') overrides widget-tree parent A ('A')
+      expect(find.text('B'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '5. dep is disposed when main module is disposed',
+    (tester) async {
+      _disposed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiScopeBuilder(
+            createModule: _MainWithDisposableDep.new,
+            builder: (context, scope) => const SizedBox(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(_disposed, isFalse);
+
+      // Remove the widget → dispose
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      await tester.pumpAndSettle();
+
+      expect(_disposed, isTrue);
+    },
+  );
+
+  testWidgets(
+    '6. notifyListeners from widget-tree parent '
+    'does not lose dep registrations',
+    (tester) async {
+      late _ModuleA parentModule;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiScopeBuilder(
+            createModule: () {
+              parentModule = _ModuleA();
+              return parentModule;
+            },
+            builder: (context, _) {
+              return DiScopeBuilder(
+                createModule: () => _MainNoOwnString([_ModuleB()]),
+                builder: (context, scope) {
+                  return Text(scope.get<String>());
+                },
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('B'), findsOneWidget);
+
+      parentModule.notifyListeners();
+      await tester.pump();
+
+      // After parent notification, dep entities must still be accessible
+      expect(find.text('B'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '7. recursive deps: A(deps:[B(deps:[C])]) — C registrations visible from A',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DiScopeBuilder(
+            createModule: () => _MainNoOwnInt([_ModuleBWithDepC()]),
+            builder: (context, scope) {
+              return Text('${scope.get<int>()}');
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('42'), findsOneWidget);
+    },
+  );
+}
+
+// Helper modules defined inline to avoid cluttering top-level
+
+class DiModule$WithDep extends DiModule {
+  DiModule$WithDep(List<BaseDiModule> deps) : super(dependencies: deps);
+
+  @override
+  void setup(SyncRegistrar it) {}
+}
+
+class _MainNoOwnString extends DiModule {
+  _MainNoOwnString(List<BaseDiModule> deps) : super(dependencies: deps);
+
+  @override
+  void setup(SyncRegistrar it) {}
+}
+
+class _MainNoOwnInt extends DiModule {
+  _MainNoOwnInt(List<BaseDiModule> deps) : super(dependencies: deps);
+
+  @override
+  void setup(SyncRegistrar it) {}
+}
+
+class _MainOverridesString extends DiModule {
+  _MainOverridesString(List<BaseDiModule> deps) : super(dependencies: deps);
+
+  @override
+  void setup(SyncRegistrar it) {
+    it.registerFactory<String>(() => 'own');
+  }
+}


### PR DESCRIPTION
### Module Dependencies

Instead of nesting multiple `DiScopeBuilder` widgets, a module can declare its own dependencies via the `dependencies`
constructor parameter. Dependency modules are initialized before the main module's `setup()` runs, and their
registrations are available through the same scope.

```dart
// Before: nested DiScopeBuilder widgets
DiScopeBuilder(
  createModule: MediaDiModule.new,
  builder: (_, __) => DiScopeBuilder(
    createModule: BannerDiModule.new,
    builder: (_, __) => DiScopeBuilder(
      createModule: ToursDiModule.new,
      builder: (context, scope) => ToursScreen(
        toursBloc: scope.get<ToursBloc>(),
        bannerBloc: scope.get<BannerBloc>(),
      ),
    ),
  ),
)
// After: single DiScopeBuilder, deps declared in the module
class ToursDiModule extends DiModule {
  ToursDiModule() : super(dependencies: [MediaDiModule(), BannerDiModule()]);
  @override
  void setup(SyncRegistrar it) {
    it.registerFactory(() => ToursBloc(repo: get<ToursRepo>()));
  }
}
DiScopeBuilder(
  createModule: ToursDiModule.new,
  builder: (context, scope) => ToursScreen(
    toursBloc: scope.get<ToursBloc>(),
    bannerBloc: scope.get<BannerBloc>(), // inherited from BannerDiModule
  ),
)
```

All dependency registrations are merged into the same `_parentEntities` map via `mergeFrom` — later deps overwrite
earlier ones for the same type. The main module's own `setup()` writes to `_entities`, which is always checked first
by `get()`.

```dart
class MyModule extends DiModule {
  // ModuleB is merged after ModuleA — its String registration wins over ModuleA's
  MyModule() : super(dependencies: [ModuleA(), ModuleB()]);
  @override
  void setup(SyncRegistrar it) {
    // registered in _entities — always wins over anything in _parentEntities
    it.registerFactory<String>(() => 'own');
  }
}
```

Dependencies are disposed automatically when the main module is disposed.